### PR TITLE
init: add pom and base classes

### DIFF
--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,0 +1,2 @@
+The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+https://github.com/artipie/git-adapter/LICENSE.txt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 artipie.com
+Copyright (c) 2021 artipie.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2021 artipie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.artipie</groupId>
+    <artifactId>ppom</artifactId>
+    <version>0.5.1</version>
+  </parent>
+  <artifactId>git-adapter</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>git-adapter</name>
+  <description>An Artipie adapter for git repositories</description>
+  <url>https://github.com/artipie/git-adapter</url>
+  <inceptionYear>2020</inceptionYear>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://github.com/artipie/git-adapter/blob/master/LICENSE.txt</url>
+    </license>
+  </licenses>
+  <properties>
+    <qulice.license>${project.basedir}/LICENSE.header</qulice.license>
+  </properties>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/artipie/git-adapter/issues</url>
+  </issueManagement>
+  <scm>
+    <connection>scm:git:git@github.com:artipie/git-adapter.git</connection>
+    <developerConnection>scm:git:git@github.com:artipie/git-adapter.git</developerConnection>
+    <url>https://github.com/artipie/git-adapter</url>
+  </scm>
+  <ciManagement>
+    <system>GitHub actions</system>
+    <url>https://github.com/artipie/git-adapter/actions</url>
+  </ciManagement>
+  <distributionManagement>
+    <site>
+      <id>Maven central</id>
+      <url>https://repo.maven.apache.org/maven2/com/artipie/git-adapter/</url>
+    </site>
+  </distributionManagement>
+  <repositories>
+    <repository>
+      <id>jgit-repository</id>
+      <url>https://repo.eclipse.org/content/groups/releases/</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <!-- Artipie -->
+    <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>asto</artifactId>
+      <version>v1.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>http</artifactId>
+      <version>v0.26.1</version>
+    </dependency>
+    <!-- JGit -->
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>5.13.0.202109080827-r</version>
+    </dependency>
+    <!-- test -->
+    <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>vertx-server</artifactId>
+      <version>0.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.16.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.8.0-alpha2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>jcabi-versionalize-packages</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>qulice</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-maven-plugin</artifactId>
+            <version>0.19.4</version>
+            <configuration>
+              <excludes combine.children="append">
+                <exclude>findbugs:.*</exclude>
+                <exclude>duplicatefinder:.*</exclude>
+                <exclude>xml:/src/it/settings.xml</exclude>
+                <exclude>dependencies:.*</exclude>
+                <exclude>checkstyle:.*/src/test/resources/.*</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/src/main/java/com/artipie/git/GitSlice.java
+++ b/src/main/java/com/artipie/git/GitSlice.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.asto.Storage;
+import com.artipie.http.Slice;
+import com.artipie.http.rq.RqParams;
+import com.artipie.http.rt.ByMethodsRule;
+import com.artipie.http.rt.RtRule;
+import com.artipie.http.rt.RtRulePath;
+import com.artipie.http.rt.SliceRoute;
+import java.util.Map.Entry;
+
+/**
+ * Git main entry point.
+ * <p>
+ * Implements git smart-http protocol for git repository.
+ * </p>
+ *
+ * @since 1.0
+ */
+public final class GitSlice extends Slice.Wrap {
+
+    /**
+     * New git slice.
+     * @param storage Repository storage
+     */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
+    public GitSlice(final Storage storage) {
+        super(
+            new SliceRoute(
+                new RtRulePath(
+                    new RtRule.All(
+                        ReceivePackSlice.RT_RULE,
+                        ByMethodsRule.Standard.GET
+                    ),
+                    new ReceivePackSlice.InfoRefSlice()
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        ReceivePackSlice.RT_RULE,
+                        ByMethodsRule.Standard.POST
+                    ),
+                    new ReceivePackSlice()
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        UploadPackSlice.RT_RULE,
+                        ByMethodsRule.Standard.GET
+                    ),
+                    new UploadPackSlice.InfoRefSlice()
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        UploadPackSlice.RT_RULE,
+                        ByMethodsRule.Standard.POST
+                    ),
+                    new UploadPackSlice()
+                )
+            )
+        );
+    }
+
+    /**
+     * Routing rule by service name.
+     *
+     * @since 1.0
+     */
+    static final class ByService implements RtRule {
+
+        /**
+         * Service name.
+         */
+        private final String name;
+
+        /**
+         * New routing rule.
+         * @param name Service name
+         */
+        ByService(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean apply(final String line, final Iterable<Entry<String, String>> headers) {
+            return new RqParams(line).value("service").map(srv -> srv.equals(this.name))
+                .orElse(false);
+        }
+    }
+}

--- a/src/main/java/com/artipie/git/ReceivePackSlice.java
+++ b/src/main/java/com/artipie/git/ReceivePackSlice.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.http.Slice;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.rt.RtRule;
+import com.artipie.http.slice.SliceSimple;
+
+/**
+ * Slice to handle {@code receive-pack} service commands to support {@code git push}
+ * commands.
+ * <p>
+ * {@code receive-pack} service is initiated by client's {@code send-pack}
+ * command which is triggered by
+ * {@code git push} to send data to server. Sending pack consists of two phases:
+ * <ol>
+ *   <li>{@code GET} HTTP request to {@code receive-pack} service to fetch references
+ *   info and server metadata</li>
+ *   <li>{@code POST} HTTP request with payload where client uploads pack to server</li>
+ * </ol>
+ * </p>
+ *
+ * @since 1.0
+ */
+final class ReceivePackSlice extends Slice.Wrap {
+
+    /**
+     * Service routing rule.
+     */
+    static final RtRule RT_RULE = new GitSlice.ByService("upload-pack");
+
+    /**
+     * New Slice.
+     */
+    ReceivePackSlice() {
+        super(new SliceSimple(new RsWithStatus(RsStatus.NOT_IMPLEMENTED)));
+    }
+
+    /**
+     * A slice to return info references as a first phase of {@code receive-pack}.
+     *
+     * @since 1.0
+     */
+    static final class InfoRefSlice extends Slice.Wrap {
+
+        /**
+         * New info refs slice.
+         */
+        InfoRefSlice() {
+            super(new SliceSimple(new RsWithStatus(RsStatus.NOT_IMPLEMENTED)));
+        }
+    }
+}

--- a/src/main/java/com/artipie/git/UploadPackSlice.java
+++ b/src/main/java/com/artipie/git/UploadPackSlice.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.http.Slice;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.rt.RtRule;
+import com.artipie.http.slice.SliceSimple;
+
+/**
+ * Slice to handle {@code upload-pack} service commands to support {@code git fetch}
+ * commands.
+ * <p>
+ * {@code upload-pack} service is initiated by client's {@code fetch-pack} command which
+ * is triggered by {@code git fetch} to receive data from server. Fetching pack consists
+ * of two phases:
+ * <ol>
+ *   <li>{@code GET} HTTP request to {@code upload-pack} service, where client is sending
+ *   own references and expects new updates to calculate the difference. Also, some server
+ *   metadata is included into the response</li>
+ *   <li>{@code POST} HTTP request to {@code upload-pack} service, where client sends
+ *   references to include into pack file, and server uploads pack to client.</li>
+ * </ol>
+ *
+ * @since 1.0
+ */
+final class UploadPackSlice extends Slice.Wrap {
+
+    /**
+     * Service routing name.
+     */
+    static final RtRule RT_RULE = new GitSlice.ByService("upload-pack");
+
+    /**
+     * New upload pack service.
+     */
+    UploadPackSlice() {
+        super(new SliceSimple(new RsWithStatus(RsStatus.NOT_IMPLEMENTED)));
+    }
+
+    /**
+     * References info phase for upload pack.
+     *
+     * @since 1.0
+     */
+    static final class InfoRefSlice extends Slice.Wrap {
+
+        /**
+         * Ne info refs slice.
+         */
+        InfoRefSlice() {
+            super(new SliceSimple(new RsWithStatus(RsStatus.NOT_IMPLEMENTED)));
+        }
+    }
+}

--- a/src/main/java/com/artipie/git/package-info.java
+++ b/src/main/java/com/artipie/git/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Main package of Artipie git-adapter.
+ * @since 1.0
+ */
+package com.artipie.git;

--- a/src/test/java/com/artipie/git/package-info.java
+++ b/src/test/java/com/artipie/git/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Tests for Artipie git adapter.
+ * @since 1.0
+ */
+package com.artipie.git;


### PR DESCRIPTION
Add `pom.xml` for project config. Add base classes
for handling smart-http protocol: `GitSlice` is an entrypoint,
other slices will be responsible for receive and upload pack commands.