### PR TITLE
feat: implement ls-refs upload-pack command

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        java: [1.8, 11, 13]
+        java: [11, 13]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -27,4 +27,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
       - name: Build it with Maven
-        run: mvn -B clean verify -Pqulice -Pjacoco
+        run: |
+          git config --global user.email "host@example.com"
+          git config --global user.name "Host"
+          mvn -B clean verify -Pqulice -Pjacoco

--- a/src/main/java/com/artipie/git/GitRequest.java
+++ b/src/main/java/com/artipie/git/GitRequest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.ArtipieException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Git request data accessor.
+ * @since 1.0
+ * @checkstyle MagicNumberCheck (300 lines)
+ * @checkstyle MethodBodyCommentsCheck (300 lines)
+ */
+final class GitRequest {
+    /**
+     * Request lines.
+     */
+    private final List<String> lines;
+
+    /**
+     * New git request.
+     * <p>
+     * Use {@link #parse(String)} to parse raw request data.
+     * </p>
+     * @param lines Request lines
+     */
+    GitRequest(final List<String> lines) {
+        this.lines = lines;
+    }
+
+    /**
+     * Parse command.
+     * @return Command if found
+     */
+    Optional<String> command() {
+        return this.lines.stream().filter(line -> line.startsWith("command="))
+            .map(line -> line.substring(8)).findFirst().map(String::trim);
+    }
+
+    /**
+     * Parsed parts.
+     * @return Immutable list
+     */
+    List<String> parts() {
+        return Collections.unmodifiableList(this.lines);
+    }
+
+    /**
+     * Parse raw request data.
+     * @param raw Request data
+     * @return Request data accessor
+     */
+    static GitRequest parse(final String raw) {
+        String rest = raw;
+        final List<String> lines = new ArrayList<>(10);
+        while (!rest.isEmpty()) {
+            if (rest.length() < 4) {
+                throw new ArtipieException("Invalid git request line lengh");
+            }
+            // parse line prefix (first 4 ASCI chars as hex digits) to integer
+            final int len = Integer.parseInt(rest.substring(0, 4), 16);
+            // sometimes git request contain length smaller than 4 instead of just skipping it
+            if (len < 4) {
+                rest = rest.substring(4);
+                continue;
+            }
+            final String line = rest.substring(4, len);
+            lines.add(line);
+            rest = rest.substring(len);
+        }
+        return new GitRequest(lines);
+    }
+}

--- a/src/main/java/com/artipie/git/GitSlice.java
+++ b/src/main/java/com/artipie/git/GitSlice.java
@@ -54,7 +54,14 @@ public final class GitSlice extends Slice.Wrap {
                         UploadPackSlice.RT_RULE,
                         ByMethodsRule.Standard.POST
                     ),
-                    new UploadPackSlice()
+                    new UploadPackSlice(storage)
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        ByMethodsRule.Standard.POST,
+                        new RtRule.ByPath("/git-upload-pack")
+                    ),
+                    new UploadPackSlice(storage)
                 ),
                 new RtRulePath(
                     new RtRule.All(

--- a/src/main/java/com/artipie/git/LsRefsSlice.java
+++ b/src/main/java/com/artipie/git/LsRefsSlice.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.asto.ArtipieIOException;
+import com.artipie.asto.Content;
+import com.artipie.asto.Copy;
+import com.artipie.asto.Storage;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rs.RsWithBody;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map.Entry;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.PacketLineOut;
+import org.eclipse.jgit.transport.RefAdvertiser;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice to handle {@code ls-refs} command.
+ *
+ * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MethodBodyCommentsCheck (500 lines)
+ */
+final class LsRefsSlice implements Slice {
+
+    /**
+     * Repository storage.
+     */
+    private final Storage storage;
+
+    /**
+     * New slice.
+     *
+     * @param storage Repo storage
+     */
+    LsRefsSlice(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public Response response(final String line, final Iterable<Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        final Path tmp;
+        try {
+            tmp = Files.createTempDirectory(LsRefsSlice.class.getName());
+        } catch (final IOException iex) {
+            throw new ArtipieIOException(iex);
+        }
+        return new AsyncResponse(
+            new TmpResource(tmp).<Response>with(
+                tsto -> new Copy(this.storage).copy(tsto).thenApply(
+                    none -> {
+                        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                        try {
+                            final Repository repo = new FileRepository(
+                                tmp.toAbsolutePath().toFile()
+                            );
+                            // every bare repository must have `HEAD` reference:
+                            // no `HEAD` means that repository doesn't exist here,
+                            // and we should create it.
+                            if (repo.resolve("HEAD") == null) {
+                                repo.create(true);
+                            }
+                            final PacketLineOut out = new PacketLineOut(baos);
+                            final RefAdvertiser adv =
+                                new RefAdvertiser.PacketLineOutRefAdvertiser(out);
+                            adv.init(repo);
+                            adv.setDerefTags(true);
+                            adv.send(repo.getRefDatabase().getRefsByPrefix("HEAD"));
+                            adv.send(repo.getRefDatabase().getRefsByPrefix("refs/"));
+                            out.end();
+                        } catch (final IOException iex) {
+                            throw new ArtipieIOException(iex);
+                        }
+                        return new Content.From(baos.toByteArray());
+                    }
+                ).thenApply(RsWithBody::new)
+            )
+        );
+    }
+}

--- a/src/main/java/com/artipie/git/TmpResource.java
+++ b/src/main/java/com/artipie/git/TmpResource.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.asto.Storage;
+import com.artipie.asto.fs.FileStorage;
+import com.artipie.asto.misc.UncheckedSupplier;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Temporary storage as resource.
+ *
+ * @since 1.0
+ */
+public final class TmpResource {
+
+    /**
+     * Tmp path factory.
+     */
+    private final Supplier<? extends Path> factory;
+
+    /**
+     * New tmp resource with fixed path.
+     *
+     * @param path Tmp path
+     */
+    public TmpResource(final Path path) {
+        this(() -> path);
+    }
+
+    /**
+     * New tmp resource with random path.
+     */
+    public TmpResource() {
+        this(
+            new UncheckedSupplier<>(
+                () -> Files.createTempDirectory(TmpResource.class.getCanonicalName())
+            )
+        );
+    }
+
+    /**
+     * Primary constructor.
+     * @param factory Tmp path factory
+     */
+    public TmpResource(final Supplier<? extends Path> factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Perform operations with this resource and cleanup after that.
+     *
+     * @param func Operation function
+     * @param <T> Result type
+     * @return Operation result
+     */
+    <T> CompletableFuture<? extends T> with(
+        final Function<? super Storage, ? extends CompletionStage<T>> func
+    ) {
+        return CompletableFuture.supplyAsync(this.factory).thenCompose(
+            (Path path) -> func.apply(new FileStorage(path)).handle(TmpResource.cleanup(path))
+        );
+    }
+
+    /**
+     * Cleanup function.
+     *
+     * @param path Path to cleanup
+     * @param <T> Return type
+     * @return Cleanup function
+     */
+    private static <T> BiFunction<? super T, Throwable, T> cleanup(final Path path) {
+        return (T res, Throwable thr) -> {
+            Throwable err = thr;
+            try {
+                Files.walkFileTree(
+                    path,
+                    new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(final Path file,
+                            final BasicFileAttributes attrs) throws IOException {
+                            Files.delete(file);
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                        @Override
+                        public FileVisitResult postVisitDirectory(final Path dir,
+                            final IOException exc) throws IOException {
+                            Files.delete(dir);
+                            return FileVisitResult.CONTINUE;
+                        }
+                    }
+                );
+            } catch (final IOException iex) {
+                if (err == null) {
+                    err = iex;
+                } else {
+                    err.addSuppressed(iex);
+                }
+            }
+            if (err != null) {
+                if (err instanceof RuntimeException) {
+                    throw (RuntimeException) err;
+                } else {
+                    throw new CompletionException(err);
+                }
+            }
+            return res;
+        };
+    }
+}

--- a/src/main/java/com/artipie/git/UploadPackSlice.java
+++ b/src/main/java/com/artipie/git/UploadPackSlice.java
@@ -4,11 +4,24 @@
  */
 package com.artipie.git;
 
+import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.http.Response;
 import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rt.RtRule;
 import com.artipie.http.slice.SliceSimple;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.reactivestreams.Publisher;
 
 /**
  * Slice to handle {@code upload-pack} service commands to support {@code git fetch}
@@ -27,7 +40,8 @@ import com.artipie.http.slice.SliceSimple;
  *
  * @since 1.0
  */
-final class UploadPackSlice extends Slice.Wrap {
+@SuppressWarnings("PMD.LongVariable")
+final class UploadPackSlice implements Slice {
 
     /**
      * Service routing name.
@@ -35,9 +49,57 @@ final class UploadPackSlice extends Slice.Wrap {
     static final RtRule RT_RULE = new GitSlice.ByService("git-upload-pack");
 
     /**
-     * New upload pack service.
+     * Error slice for command not found.
      */
-    UploadPackSlice() {
-        super(new SliceSimple(new RsWithStatus(RsStatus.NOT_IMPLEMENTED)));
+    private static final Slice SLICE_CMD_NOT_FOUND = new SliceSimple(
+        new RsWithBody(
+            new RsWithStatus(RsStatus.BAD_REQUEST),
+            "command not found", StandardCharsets.US_ASCII
+        )
+    );
+
+    /**
+     * Error slice for bad request response.
+     */
+    private static final Slice SLICE_BAD_REQUEST = new SliceSimple(
+        new RsWithStatus(RsStatus.BAD_REQUEST)
+    );
+
+    /**
+     * Commands mapping.
+     */
+    private final Map<String, Slice> commands;
+
+    /**
+     * New upload pack service.
+     * @param storage Repository storage
+     */
+    UploadPackSlice(final Storage storage) {
+        this.commands = buildCommands(storage);
+    }
+
+    @Override
+    public Response response(final String line, final Iterable<Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        final Publisher<ByteBuffer> cache = Flowable.fromPublisher(body).cache();
+        return new AsyncResponse(
+            new PublisherAs(cache).asciiString().thenApply(GitRequest::parse).thenApply(
+                req -> req.command().map(
+                    name -> this.commands.getOrDefault(name, UploadPackSlice.SLICE_CMD_NOT_FOUND)
+                ).orElse(UploadPackSlice.SLICE_BAD_REQUEST)
+            ).thenApply(slice -> slice.response(line, headers, body))
+        );
+    }
+
+    /**
+     * Build upload-pack service command slices.
+     *
+     * @param storage Repository storage
+     * @return Mapping of command names to slice objects
+     */
+    private static Map<String, Slice> buildCommands(final Storage storage) {
+        final Map<String, Slice> map = new HashMap<>(1);
+        map.put("ls-refs", new LsRefsSlice(storage));
+        return Collections.unmodifiableMap(map);
     }
 }

--- a/src/test/java/com/artipie/git/GitRequestTest.java
+++ b/src/test/java/com/artipie/git/GitRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link GitRequest}.
+ *
+ * @since 1.0
+ */
+class GitRequestTest {
+
+    @Test
+    void parseParts() {
+        MatcherAssert.assertThat(
+            GitRequest.parse("0012AABBCCDDEEFFGG0006BB0000").parts(),
+            Matchers.contains("AABBCCDDEEFFGG", "BB")
+        );
+    }
+
+    @Test
+    void parseEmpty() {
+        MatcherAssert.assertThat(
+            GitRequest.parse("0000").parts(),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void skipSmallLengths() {
+        MatcherAssert.assertThat(
+            GitRequest.parse("0006AB00010006CD0000").parts(),
+            Matchers.contains("AB", "CD")
+        );
+    }
+
+    @Test
+    void parseCommand() {
+        MatcherAssert.assertThat(
+            GitRequest.parse("0010command=foo\n0000").command().get(),
+            Matchers.equalTo("foo")
+        );
+    }
+}

--- a/src/test/java/com/artipie/git/TmpResourceTest.java
+++ b/src/test/java/com/artipie/git/TmpResourceTest.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * Test case for {@link TmpResource}.
+ *
+ * @since 1.0
+ */
+final class TmpResourceTest {
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    void removeFilesOnCleanup(@TempDir final Path tmp) throws Exception {
+        final Path target = tmp.resolve("test-1");
+        Files.createDirectory(target);
+        new TmpResource(target)
+            .with(
+                st -> CompletableFuture.allOf(
+                    st.save(new Key.From("one"), new Content.From("1".getBytes())),
+                    st.save(new Key.From("dir", "two"), new Content.From("2".getBytes())),
+                    st.save(new Key.From("dir", "three"), new Content.From("3".getBytes())),
+                    st.save(new Key.From("four"), new Content.From("4".getBytes()))
+                )
+            ).join();
+        MatcherAssert.assertThat(
+            Files.exists(target),
+            Matchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
Implement `ls-refs` command handling of `git-upload-pack` service:
 * implement command parsing of git client.
 * add `LsRefsSlice` to handle `ls-refs` command of `git-upload-pack`
service.
 * add `TmpResource` to copy git repository from storage to temp
   directory.
 * implement command routing for upload-pack service.
 * enable and fix integration test for `ls-refs` command.