### PR TITLE
refactoring: extracted SDK classes

### DIFF
--- a/src/main/java/com/artipie/git/TmpResource.java
+++ b/src/main/java/com/artipie/git/TmpResource.java
@@ -67,7 +67,7 @@ public final class TmpResource {
      * @param <T> Result type
      * @return Operation result
      */
-    <T> CompletableFuture<? extends T> with(
+    public <T> CompletableFuture<? extends T> with(
         final Function<? super Storage, ? extends CompletionStage<T>> func
     ) {
         return CompletableFuture.supplyAsync(this.factory).thenCompose(

--- a/src/main/java/com/artipie/git/http/GitResponseOutput.java
+++ b/src/main/java/com/artipie/git/http/GitResponseOutput.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.http;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/src/main/java/com/artipie/git/http/GitSlice.java
+++ b/src/main/java/com/artipie/git/http/GitSlice.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.http;
 
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;

--- a/src/main/java/com/artipie/git/http/InfoRefsSlice.java
+++ b/src/main/java/com/artipie/git/http/InfoRefsSlice.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.http;
 
 import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;

--- a/src/main/java/com/artipie/git/http/LsRefsSlice.java
+++ b/src/main/java/com/artipie/git/http/LsRefsSlice.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+package com.artipie.git.http;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Storage;
+import com.artipie.git.sdk.Git;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rs.RsWithBody;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Map.Entry;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice to handle {@code ls-refs} command.
+ *
+ * @since 1.0
+ */
+final class LsRefsSlice implements Slice {
+
+    /**
+     * Repository storage.
+     */
+    private final Storage storage;
+
+    /**
+     * New slice.
+     *
+     * @param storage Repo storage
+     */
+    LsRefsSlice(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public Response response(final String line, final Iterable<Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        return new AsyncResponse(
+            new Git(this.storage).lsRefs(baos)
+                .thenApply(none -> new RsWithBody(new Content.From(baos.toByteArray())))
+        );
+    }
+}

--- a/src/main/java/com/artipie/git/http/ReceivePackSlice.java
+++ b/src/main/java/com/artipie/git/http/ReceivePackSlice.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.http;
 
 import com.artipie.http.Slice;
 import com.artipie.http.rs.RsStatus;

--- a/src/main/java/com/artipie/git/http/UploadPackSlice.java
+++ b/src/main/java/com/artipie/git/http/UploadPackSlice.java
@@ -2,10 +2,11 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.http;
 
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
+import com.artipie.git.sdk.GitRequest;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;

--- a/src/main/java/com/artipie/git/http/package-info.java
+++ b/src/main/java/com/artipie/git/http/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Git smart-http implementation.
+ * @since 1.0
+ */
+package com.artipie.git.http;

--- a/src/main/java/com/artipie/git/sdk/GitRequest.java
+++ b/src/main/java/com/artipie/git/sdk/GitRequest.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.sdk;
 
 import com.artipie.ArtipieException;
 import java.util.ArrayList;
@@ -16,7 +16,7 @@ import java.util.Optional;
  * @checkstyle MagicNumberCheck (300 lines)
  * @checkstyle MethodBodyCommentsCheck (300 lines)
  */
-final class GitRequest {
+public final class GitRequest {
     /**
      * Request lines.
      */
@@ -37,7 +37,7 @@ final class GitRequest {
      * Parse command.
      * @return Command if found
      */
-    Optional<String> command() {
+    public Optional<String> command() {
         return this.lines.stream().filter(line -> line.startsWith("command="))
             .map(line -> line.substring(8)).findFirst().map(String::trim);
     }
@@ -46,7 +46,7 @@ final class GitRequest {
      * Parsed parts.
      * @return Immutable list
      */
-    List<String> parts() {
+    public List<String> parts() {
         return Collections.unmodifiableList(this.lines);
     }
 
@@ -54,8 +54,10 @@ final class GitRequest {
      * Parse raw request data.
      * @param raw Request data
      * @return Request data accessor
+     * @throws ArtipieException In case of request is invalid
      */
-    static GitRequest parse(final String raw) {
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static GitRequest parse(final String raw) {
         String rest = raw;
         final List<String> lines = new ArrayList<>(10);
         while (!rest.isEmpty()) {

--- a/src/main/java/com/artipie/git/sdk/package-info.java
+++ b/src/main/java/com/artipie/git/sdk/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Git SDK objects.
+ * @since 1.0
+ */
+package com.artipie.git.sdk;

--- a/src/test/java/com/artipie/git/http/GitResponseOutputTest.java
+++ b/src/test/java/com/artipie/git/http/GitResponseOutputTest.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.http;
 
 import com.artipie.asto.misc.UncheckedConsumer;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/com/artipie/git/http/package-info.java
+++ b/src/test/java/com/artipie/git/http/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Tests for HTTP layer.
+ * @since 1.0
+ */
+package com.artipie.git.http;

--- a/src/test/java/com/artipie/git/it/Cmd.java
+++ b/src/test/java/com/artipie/git/it/Cmd.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.it;
 
 import com.artipie.asto.misc.UncheckedConsumer;
 import com.jcabi.log.Logger;

--- a/src/test/java/com/artipie/git/it/GitITCase.java
+++ b/src/test/java/com/artipie/git/it/GitITCase.java
@@ -2,9 +2,10 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.it;
 
 import com.artipie.asto.fs.FileStorage;
+import com.artipie.git.http.GitSlice;
 import com.artipie.http.slice.LoggingSlice;
 import com.artipie.vertx.VertxSliceServer;
 import com.jcabi.log.Logger;

--- a/src/test/java/com/artipie/git/it/package-info.java
+++ b/src/test/java/com/artipie/git/it/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Integration tests.
+ * @since 1.0
+ */
+package com.artipie.git.it;

--- a/src/test/java/com/artipie/git/sdk/GitRequestTest.java
+++ b/src/test/java/com/artipie/git/sdk/GitRequestTest.java
@@ -2,8 +2,9 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/git-adapter/LICENSE.txt
  */
-package com.artipie.git;
+package com.artipie.git.sdk;
 
+import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 1.0
  */
-class GitRequestTest {
+final class GitRequestTest {
 
     @Test
     void parseParts() {
@@ -42,7 +43,7 @@ class GitRequestTest {
     @Test
     void parseCommand() {
         MatcherAssert.assertThat(
-            GitRequest.parse("0010command=foo\n0000").command().get(),
+            new GitRequest(Arrays.asList("command=foo")).command().get(),
             Matchers.equalTo("foo")
         );
     }

--- a/src/test/java/com/artipie/git/sdk/package-info.java
+++ b/src/test/java/com/artipie/git/sdk/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/git-adapter/LICENSE.txt
+ */
+
+/**
+ * Tests for git SDK.
+ * @since 1.0
+ */
+package com.artipie.git.sdk;


### PR DESCRIPTION
Move logic related to SDK to separate package classes.
Make SDK classes public.

Ticket: #18