### PR TITLE
fix: downgrade jgit dep

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        java: [11, 13]
+        java: [8, 11, 13]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>6.0.0.202111291000-r</version>
+      <version>5.9.0.202009080501-r</version>
     </dependency>
     <!-- test -->
     <dependency>


### PR DESCRIPTION
CI and CD for 8 JVM are broken because 6 jgit version
was compiled against newer Java target 56 class version.
Downgrade jgit to 5 version to build with 8 JDK.